### PR TITLE
Handle indented sections

### DIFF
--- a/lib/configparser.rb
+++ b/lib/configparser.rb
@@ -23,7 +23,7 @@ class ConfigParser < Hash
 					key = $1
 					self[key] = $2
 				end
-			elsif line =~ /^\[(.+?)\]/ # handle new sections
+			elsif line =~ /^\s*\[(.+?)\]/ # handle new sections
 				section = $1
 			elsif line =~ /^\s+(.+?)$/ # handle continued lines
 				if section


### PR DESCRIPTION
According to the ConfigParser docs, sections can be indented: https://docs.python.org/3/library/configparser.html

The code at the moment will treat an indented section as a continued line from the previous key value pair.
